### PR TITLE
Allow dependabot to check dockerfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "Docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
# Description

This change allows dependabot to check the dockerfile and submit automatic PRs with version bumps so that the image always uses the latest version of terraform-docs.

https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates