### PR TITLE
Add 'fail-on-diff' parameter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,3 +77,11 @@ jobs:
           working-dir: examples/tf12_config
           output-file: README.md
           config-file: .terraform-docs.yml
+
+      - name: Should generate README.md for tf12_fail_diff and fail on diff
+        uses: ./
+        with:
+          working-dir: examples/tf12_fail_diff
+          output-file: README.md
+          indention: 3
+          fail-on-diff: true

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ jobs:
 | args | Additional arguments to pass to the command (see [full documentation](https://github.com/terraform-docs/terraform-docs/tree/master/docs)) | `` | false |
 | atlantis-file | Name of Atlantis file to extract list of directories by parsing it. To enable, provide the file name (e.g. `atlantis.yaml`) | `disabled` | false |
 | config-file | Name of terraform-docs config file. To enable, provide the file name (e.g. `.terraform-docs.yml`) | `disabled` | false |
+| fail-on-diff | Fail the job if there is any diff found between the generated output and existing file (ignored if `git-push` is set) | `false` | false |
 | find-dir | Name of root directory to extract list of directories by running `find ./find\_dir -name \*.tf` (ignored if `atlantis-file` is set) | `disabled` | false |
 | git-commit-message | Commit message | `terraform-docs: automated action` | false |
 | git-push | If true it will commit and push the changes | `false` | false |

--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,10 @@ inputs:
     description: Commit message
     required: false
     default: "terraform-docs: automated action"
+  fail-on-diff:
+    description: Fail the job if there is any diff found between the generated output and existing file (ignored if `git-push` is set)
+    required: false
+    default: "false"
 
 outputs:
   num_changed:
@@ -76,6 +80,7 @@ runs:
     - ${{ inputs.git-push }}
     - ${{ inputs.git-commit-message }}
     - ${{ inputs.config-file }}
+    - ${{ inputs.fail-on-diff }}
 
 branding:
   icon: file-text

--- a/examples/tf12_fail_diff/README.md
+++ b/examples/tf12_fail_diff/README.md
@@ -1,0 +1,52 @@
+# Test tf12 with fail on diff
+
+## Input
+
+```yaml
+- name: Should generate README.md for tf12_fail_diff and fail on diff
+  uses: ./
+  with:
+    working-dir: examples/tf12_fail_diff
+    output-file: README.md
+    fail-on-diff: true
+```
+
+## Verify
+
+- Should inject below Usage in README.md
+
+## Usage
+
+<!--- BEGIN_TF_DOCS --->
+### Requirements
+
+| Name | Version |
+|------|---------|
+| aws | ~> 2.20.0 |
+| consul | >= 2.4.0 |
+
+### Providers
+
+| Name | Version |
+|------|---------|
+| aws | ~> 2.20.0 |
+| consul | >= 2.4.0 |
+
+### Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| extra\_environment | List of additional environment variables | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | `[]` | no |
+| extra\_tags | Additional tags | `map(string)` | `{}` | no |
+| instance\_count | Number of instances to create | `number` | `1` | no |
+| instance\_name | Instance name prefix | `string` | `"test-"` | no |
+| subnet\_ids | A list of subnet ids to use | `list(string)` | n/a | yes |
+| vpc\_id | The id of the vpc | `string` | n/a | yes |
+
+### Outputs
+
+| Name | Description |
+|------|-------------|
+| vpc\_id | The Id of the VPC |
+
+<!--- END_TF_DOCS --->

--- a/examples/tf12_fail_diff/main.tf
+++ b/examples/tf12_fail_diff/main.tf
@@ -1,0 +1,1 @@
+../tf12_basic/main.tf


### PR DESCRIPTION
# Description

When this is set to true, the step will fail the build if there is any
diff found between generated output and existing file (e.g. README.md).
