### PR TITLE
Change examples to use `terraform-docs/gh-actions` name

### DIFF
--- a/.github/templates/README.tpl
+++ b/.github/templates/README.tpl
@@ -37,7 +37,7 @@ jobs:
         ref: {{"${{"}} github.event.pull_request.head.ref {{"}}"}}
 
     - name: Render terraform docs inside the USAGE.md and push changes back to PR branch
-      uses: terraform-docs/terraform-docs-gh-actions@{{ $version }}
+      uses: terraform-docs/gh-actions@{{ $version }}
       with:
         working-dir: .
         output-file: USAGE.md
@@ -126,7 +126,7 @@ To enable you need to ensure a few things first:
 
 ```yaml
 - name: Generate TF Docs
-  uses: terraform-docs/terraform-docs-gh-actions@{{ $version }}
+  uses: terraform-docs/gh-actions@{{ $version }}
   with:
     working-dir: .
     output-file: README.md
@@ -136,7 +136,7 @@ To enable you need to ensure a few things first:
 
 ```yaml
 - name: Generate TF Docs
-  uses: terraform-docs/terraform-docs-gh-actions@{{ $version }}
+  uses: terraform-docs/gh-actions@{{ $version }}
   with:
     working-dir: .,example1,example3/modules/test
     output-file: README.md
@@ -146,7 +146,7 @@ To enable you need to ensure a few things first:
 
 ```yaml
 - name: Generate TF docs
-  uses: terraform-docs/terraform-docs-gh-actions@{{ $version }}
+  uses: terraform-docs/gh-actions@{{ $version }}
   with:
     atlantis-file: atlantis.yaml
 ```
@@ -155,7 +155,7 @@ To enable you need to ensure a few things first:
 
 ```yaml
 - name: Generate TF docs
-  uses: terraform-docs/terraform-docs-gh-actions@{{ $version }}
+  uses: terraform-docs/gh-actions@{{ $version }}
   with:
     find-dir: examples/
 ```

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ jobs:
         ref: ${{ github.event.pull_request.head.ref }}
 
     - name: Render terraform docs inside the USAGE.md and push changes back to PR branch
-      uses: terraform-docs/terraform-docs-gh-actions@v0.3.0
+      uses: terraform-docs/gh-actions@v0.3.0
       with:
         working-dir: .
         output-file: USAGE.md
@@ -126,7 +126,7 @@ To enable you need to ensure a few things first:
 
 ```yaml
 - name: Generate TF Docs
-  uses: terraform-docs/terraform-docs-gh-actions@v0.3.0
+  uses: terraform-docs/gh-actions@v0.3.0
   with:
     working-dir: .
     output-file: README.md
@@ -136,7 +136,7 @@ To enable you need to ensure a few things first:
 
 ```yaml
 - name: Generate TF Docs
-  uses: terraform-docs/terraform-docs-gh-actions@v0.3.0
+  uses: terraform-docs/gh-actions@v0.3.0
   with:
     working-dir: .,example1,example3/modules/test
     output-file: README.md
@@ -146,7 +146,7 @@ To enable you need to ensure a few things first:
 
 ```yaml
 - name: Generate TF docs
-  uses: terraform-docs/terraform-docs-gh-actions@v0.3.0
+  uses: terraform-docs/gh-actions@v0.3.0
   with:
     atlantis-file: atlantis.yaml
 ```
@@ -155,7 +155,7 @@ To enable you need to ensure a few things first:
 
 ```yaml
 - name: Generate TF docs
-  uses: terraform-docs/terraform-docs-gh-actions@v0.3.0
+  uses: terraform-docs/gh-actions@v0.3.0
   with:
     find-dir: examples/
 ```

--- a/scripts/update-readme.sh
+++ b/scripts/update-readme.sh
@@ -7,7 +7,7 @@ NEW_VERSION=$1
 PWD=$(cd "$(dirname "$0")" && pwd -P)
 
 if [ -z "${NEW_VERSION}" ]; then
-    NEW_VERSION=$(grep "uses: terraform-docs/terraform-docs-gh-actions" "${PWD}"/../README.md | tr -s ' ' | uniq | cut -d"@" -f2)
+    NEW_VERSION=$(grep "uses: terraform-docs/gh-actions" "${PWD}"/../README.md | tr -s ' ' | uniq | cut -d"@" -f2)
 fi
 
 if [ -z "${NEW_VERSION}" ]; then


### PR DESCRIPTION
# Description
Thanks a lot for this. I just started using it, and it's quite nice to have it automatically create the variables table. Just noticed one thing with the name. It looks like Github Marketplace has it slightly different:

![image](https://user-images.githubusercontent.com/7545665/104546570-78b14300-55fa-11eb-9f72-af03ac87117e.png)

# Changes
- Change the Action name in the examples from `terraform-docs/terraform-docs-gh-actions` to `terraform-docs/gh-actions`.

Thanks again for your work on this!