### PR TITLE
Add new parameters 'user-name' and 'user-email'

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ jobs:
 | git-commit-message | Commit message | `terraform-docs: automated action` | false |
 | git-push | If true it will commit and push the changes | `false` | false |
 | git-push-sign-off | If true it will sign-off commit | `false` | false |
+| git-push-user-email | If empty the no-reply email of the PR author will be used (i.e. `${GITHUB\_ACTOR}@users.noreply.github.com`) | `` | false |
+| git-push-user-name | If empty the name of the PR author will be used (i.e. `${GITHUB\_ACTOR}`) | `` | false |
 | indention | Indention level of Markdown sections [1, 2, 3, 4, 5] | `2` | false |
 | output-file | File in module directory where the docs should be placed | `USAGE.md` | false |
 | output-format | terraform-docs format to generate content (see [all formats](https://github.com/terraform-docs/terraform-docs/blob/master/docs/FORMATS\_GUIDE.md)) (ignored if `config-file` is set) | `markdown table` | false |

--- a/action.yml
+++ b/action.yml
@@ -51,6 +51,14 @@ inputs:
     description: If true it will commit and push the changes
     required: false
     default: "false"
+  git-push-user-name:
+    description: If empty the name of the PR author will be used (i.e. `${GITHUB_ACTOR}`)
+    required: false
+    default: ""
+  git-push-user-email:
+    description: If empty the no-reply email of the PR author will be used (i.e. `${GITHUB_ACTOR}@users.noreply.github.com`)
+    required: false
+    default: ""
   git-commit-message:
     description: Commit message
     required: false
@@ -86,6 +94,8 @@ runs:
     - ${{ inputs.config-file }}
     - ${{ inputs.fail-on-diff }}
     - ${{ inputs.git-push-sign-off }}
+    - ${{ inputs.git-push-user-name }}
+    - ${{ inputs.git-push-user-email }}
 
 branding:
   icon: file-text

--- a/src/docker-entrypoint.sh
+++ b/src/docker-entrypoint.sh
@@ -16,7 +16,9 @@ GIT_PUSH="${10}"
 GIT_COMMIT_MESSAGE="${11}"
 CONFIG_FILE="${12}"
 FAIL_ON_DIFF="${13}"
-GIT_PUSH_SIGN_OFF="${13}"
+GIT_PUSH_SIGN_OFF="${14}"
+GIT_PUSH_USER_NAME="${15}"
+GIT_PUSH_USER_EMAIL="${16}"
 
 if [ "${CONFIG_FILE}" == "disabled" ]; then
   case "$OUTPUT_FORMAT" in
@@ -35,8 +37,18 @@ if [ "${CONFIG_FILE}" == "disabled" ]; then
 fi
 
 git_setup() {
-  git config --global user.name "${GITHUB_ACTOR}"
-  git config --global user.email "${GITHUB_ACTOR}"@users.noreply.github.com
+  if [ -n "${GIT_PUSH_USER_NAME}" ]; then
+    git config --global user.name "${GIT_PUSH_USER_NAME}"
+  else
+    git config --global user.name "${GITHUB_ACTOR}"
+  fi
+
+  if [ -n "${GIT_PUSH_USER_EMAIL}" ]; then
+    git config --global user.email "${GIT_PUSH_USER_EMAIL}"
+  else
+    git config --global user.email "${GITHUB_ACTOR}"@users.noreply.github.com
+  fi
+
   git fetch --depth=1 origin +refs/tags/*:refs/tags/* || true
 }
 


### PR DESCRIPTION
# Description

These will override the default git `user.name` and `user.email` settings
when creating a new commit of the changes

Fixes #16 
