### PR TITLE
Appease markdown lint for empty value inputs

### DIFF
--- a/.github/templates/README.tpl
+++ b/.github/templates/README.tpl
@@ -55,7 +55,7 @@ jobs:
 | Name | Description | Default | Required |
 |------|-------------|---------|----------|
 {{- range $key, $input := $action.inputs }}
-| {{ tmpl.Exec "escape_chars" $key }} | {{ if (has $input "description") }}{{ tmpl.Exec "sanatize_string" $input.description }}{{ else }}{{ tmpl.Exec "escape_chars" $key }}{{ end }} | {{ if (has $input "default") }}`{{ tmpl.Exec "sanatize_string" $input.default }}`{{ else }}N/A{{ end }} | {{ if (has $input "required") }}{{ $input.required }}{{ else }}false{{ end }} |
+| {{ tmpl.Exec "escape_chars" $key }} | {{ if (has $input "description") }}{{ tmpl.Exec "sanatize_string" $input.description }}{{ else }}{{ tmpl.Exec "escape_chars" $key }}{{ end }} | {{ if (has $input "default") }}`{{ if $input.default }}{{ tmpl.Exec "sanatize_string" $input.default }}{{ else }}""{{ end }}`{{ else }}N/A{{ end }} | {{ if (has $input "required") }}{{ $input.required }}{{ else }}false{{ end }} |
 {{- end }}
 
 #### Output Method (output-method)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Should generate USAGE.md for tf11_basic
         uses: ./

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ jobs:
 
 | Name | Description | Default | Required |
 |------|-------------|---------|----------|
-| args | Additional arguments to pass to the command (see [full documentation](https://github.com/terraform-docs/terraform-docs/tree/master/docs)) | `` | false |
+| args | Additional arguments to pass to the command (see [full documentation](https://github.com/terraform-docs/terraform-docs/tree/master/docs)) | `""` | false |
 | atlantis-file | Name of Atlantis file to extract list of directories by parsing it. To enable, provide the file name (e.g. `atlantis.yaml`) | `disabled` | false |
 | config-file | Name of terraform-docs config file. To enable, provide the file name (e.g. `.terraform-docs.yml`) | `disabled` | false |
 | fail-on-diff | Fail the job if there is any diff found between the generated output and existing file (ignored if `git-push` is set) | `false` | false |
@@ -54,8 +54,8 @@ jobs:
 | git-commit-message | Commit message | `terraform-docs: automated action` | false |
 | git-push | If true it will commit and push the changes | `false` | false |
 | git-push-sign-off | If true it will sign-off commit | `false` | false |
-| git-push-user-email | If empty the no-reply email of the PR author will be used (i.e. `${GITHUB\_ACTOR}@users.noreply.github.com`) | `` | false |
-| git-push-user-name | If empty the name of the PR author will be used (i.e. `${GITHUB\_ACTOR}`) | `` | false |
+| git-push-user-email | If empty the no-reply email of the PR author will be used (i.e. `${GITHUB\_ACTOR}@users.noreply.github.com`) | `""` | false |
+| git-push-user-name | If empty the name of the PR author will be used (i.e. `${GITHUB\_ACTOR}`) | `""` | false |
 | indention | Indention level of Markdown sections [1, 2, 3, 4, 5] | `2` | false |
 | output-file | File in module directory where the docs should be placed | `USAGE.md` | false |
 | output-format | terraform-docs format to generate content (see [all formats](https://github.com/terraform-docs/terraform-docs/blob/master/docs/FORMATS\_GUIDE.md)) (ignored if `config-file` is set) | `markdown table` | false |


### PR DESCRIPTION
Signed-off-by: Khosrow Moossavi <khos2ow@gmail.com>

<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/Jt3K5 if this is your first time opening a
terraform-docs pull request. Find us in https://slack.terraform-docs.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open terraform-docs issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Make sure default column of empty value inputs (e.g. `args`) are being render rendered as `""` to appease Markdown linters.

I have:

- [x] Read and followed terraform-docs' [contribution process].

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

not applicable.

[contribution process]: https://git.io/Jt3K5
