### PR TITLE
Properly extract comma separated working directories

### DIFF
--- a/src/docker-entrypoint.sh
+++ b/src/docker-entrypoint.sh
@@ -185,7 +185,7 @@ elif [ -n "${FIND_DIR}" ] && [ "${FIND_DIR}" != "disabled" ]; then
   done < <(find "${FIND_DIR}" -name '*.tf' -exec dirname {} \; | uniq)
 else
   # Split WORKING_DIR by commas
-  for project_dir in ${WORKING_DIR//,/}; do
+  for project_dir in ${WORKING_DIR//,/ }; do
     update_doc "${project_dir}"
   done
 fi


### PR DESCRIPTION
<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/Jt3K5 if this is your first time opening a
terraform-docs pull request. Find us in https://slack.terraform-docs.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open terraform-docs issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Properly extract items separated by `,` from `working-dir` config item. For example `.,module-a,module-b` will correctly result in:

- `.`
- `module-a`
- `module-b`

Fixes #36 

I have:

- [x] Read and followed terraform-docs' [contribution process].

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/Jt3K5
