### PR TITLE
fix: don't impersonante users

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ jobs:
 | git-commit-message | Commit message | `terraform-docs: automated action` | false |
 | git-push | If true it will commit and push the changes | `false` | false |
 | git-push-sign-off | If true it will sign-off commit | `false` | false |
-| git-push-user-email | If empty the no-reply email of the PR author will be used (i.e. `${GITHUB\_ACTOR}@users.noreply.github.com`) | `""` | false |
-| git-push-user-name | If empty the name of the PR author will be used (i.e. `${GITHUB\_ACTOR}`) | `""` | false |
+| git-push-user-email | If empty the no-reply email of the GitHub Actions bot will be used (i.e. `github-actions[bot]@users.noreply.github.com`) | `""` | false |
+| git-push-user-name | If empty the name of the GitHub Actions bot will be used (i.e. `github-actions[bot]`) | `""` | false |
 | indention | Indention level of Markdown sections [1, 2, 3, 4, 5] | `2` | false |
 | output-file | File in module directory where the docs should be placed | `USAGE.md` | false |
 | output-format | terraform-docs format to generate content (see [all formats](https://github.com/terraform-docs/terraform-docs/blob/master/docs/FORMATS\_GUIDE.md)) (ignored if `config-file` is set) | `markdown table` | false |

--- a/action.yml
+++ b/action.yml
@@ -52,11 +52,11 @@ inputs:
     required: false
     default: "false"
   git-push-user-name:
-    description: If empty the name of the PR author will be used (i.e. `${GITHUB_ACTOR}`)
+    description: If empty the name of the GitHub Actions bot will be used (i.e. `github-actions[bot]`)
     required: false
     default: ""
   git-push-user-email:
-    description: If empty the no-reply email of the PR author will be used (i.e. `${GITHUB_ACTOR}@users.noreply.github.com`)
+    description: If empty the no-reply email of the GitHub Actions bot will be used (i.e. `github-actions[bot]@users.noreply.github.com`)
     required: false
     default: ""
   git-commit-message:

--- a/src/docker-entrypoint.sh
+++ b/src/docker-entrypoint.sh
@@ -54,13 +54,13 @@ git_setup() {
     if [ -n "${GIT_PUSH_USER_NAME}" ]; then
         git config --global user.name "${GIT_PUSH_USER_NAME}"
     else
-        git config --global user.name "${GITHUB_ACTOR}"
+        git config --global user.name github-actions[bot]
     fi
 
     if [ -n "${GIT_PUSH_USER_EMAIL}" ]; then
         git config --global user.email "${GIT_PUSH_USER_EMAIL}"
     else
-        git config --global user.email "${GITHUB_ACTOR}"@users.noreply.github.com
+        git config --global user.email github-actions[bot]@users.noreply.github.com
     fi
 
     git fetch --depth=1 origin +refs/tags/*:refs/tags/* || true


### PR DESCRIPTION
### Description of your changes

Impersonating the commit author of the previous commit to me is unexpected and unwanted behaviour, it's a GitHub Action, so committing via the bot user makes more sense to me

I have:
- [x] Read and followed terraform-docs' [contribution process].

### How has this code been tested

don't know how I'd test it
