### PR TITLE
Checkout breaking change

### DIFF
--- a/src/docker-entrypoint.sh
+++ b/src/docker-entrypoint.sh
@@ -21,20 +21,6 @@ set -o errtrace
 # shellcheck disable=SC2206
 cmd_args=(${INPUT_OUTPUT_FORMAT})
 
-# shellcheck disable=SC2206
-cmd_args+=(${INPUT_ARGS})
-
-if [ "${INPUT_CONFIG_FILE}" = "disabled" ]; then
-    case "$INPUT_OUTPUT_FORMAT" in
-    "asciidoc" | "asciidoc table" | "asciidoc document")
-        cmd_args+=(--indent "${INPUT_INDENTION}")
-        ;;
-
-    "markdown" | "markdown table" | "markdown document")
-        cmd_args+=(--indent "${INPUT_INDENTION}")
-        ;;
-    esac
-
     if [ -z "${INPUT_TEMPLATE}" ]; then
         INPUT_TEMPLATE=$(printf '<!-- BEGIN_TF_DOCS -->\n{{ .Content }}\n<!-- END_TF_DOCS -->')
     fi
@@ -52,6 +38,11 @@ git_setup() {
     git config --global user.name "${INPUT_GIT_PUSH_USER_NAME}"
     git config --global user.email "${INPUT_GIT_PUSH_USER_EMAIL}"
     git fetch --depth=1 origin +refs/tags/*:refs/tags/* || true
+
+    # When the runner maps the $GITHUB_WORKSPACE mount, it is owned by the runner user,
+    # while the created folders are owned by the container user, causing this error.
+    # Issue description here: https://github.com/actions/checkout/issues/766
+    git config --global --add safe.directory "$GITHUB_WORKSPACE"
 }
 
 git_add() {

--- a/src/docker-entrypoint.sh
+++ b/src/docker-entrypoint.sh
@@ -18,8 +18,23 @@ set -o errexit
 set -o pipefail
 set -o errtrace
 
+set -x
 # shellcheck disable=SC2206
 cmd_args=(${INPUT_OUTPUT_FORMAT})
+
+# shellcheck disable=SC2206
+cmd_args+=(${INPUT_ARGS})
+
+if [ "${INPUT_CONFIG_FILE}" = "disabled" ]; then
+    case "$INPUT_OUTPUT_FORMAT" in
+    "asciidoc" | "asciidoc table" | "asciidoc document")
+        cmd_args+=(--indent "${INPUT_INDENTION}")
+        ;;
+
+    "markdown" | "markdown table" | "markdown document")
+        cmd_args+=(--indent "${INPUT_INDENTION}")
+        ;;
+    esac
 
     if [ -z "${INPUT_TEMPLATE}" ]; then
         INPUT_TEMPLATE=$(printf '<!-- BEGIN_TF_DOCS -->\n{{ .Content }}\n<!-- END_TF_DOCS -->')
@@ -38,7 +53,6 @@ git_setup() {
     git config --global user.name "${INPUT_GIT_PUSH_USER_NAME}"
     git config --global user.email "${INPUT_GIT_PUSH_USER_EMAIL}"
     git fetch --depth=1 origin +refs/tags/*:refs/tags/* || true
-
     # When the runner maps the $GITHUB_WORKSPACE mount, it is owned by the runner user,
     # while the created folders are owned by the container user, causing this error.
     # Issue description here: https://github.com/actions/checkout/issues/766
@@ -174,5 +188,5 @@ else
         exit 1
     fi
 fi
-
+set +x
 exit 0


### PR DESCRIPTION
fixing git breaking change, described here: https://github.com/actions/checkout/issues/766
Attempts to use git calls in an action where the user on the folder doesn't match the current user will fail. This comes about because of the way GitHub Actions mounts the $GITHUB_WORKSPACE directory on the parent container filesystem. Global setting introduced as workaround, this fix applies the setting.

