### PR TITLE
docs: default action inputs values for config-file

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ inputs:
     required: false
     default: "markdown table"
   output-method:
-    description: Method should be one of `replace`, `inject`, or `print`
+    description: Method should be one of `replace`, `inject`, or `print`. Set as an empty string if `output.mode` and `output.file` are defined in config-file
     required: false
     default: "inject"
   output-file:
@@ -40,7 +40,7 @@ inputs:
     required: false
     default: "README.md"
   template:
-    description: When provided will be used as the template if/when the `output-file` does not exist
+    description: When provided will be used as the template if/when the `output-file` does not exist. Set as an empty string if `output.template` is defined in config-file
     default: |-
       <!-- BEGIN_TF_DOCS -->
       {{ .Content }}


### PR DESCRIPTION
Signed-off-by: Alexander Korpusov <Alexander.Korpusov@gjensidige.no>

<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/Jt3K5 if this is your first time opening a
terraform-docs pull request. Find us in https://slack.terraform-docs.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open terraform-docs issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->
When `output-method`, `output-file`, `template` are not set as an action input, the default values prevent from getting `output.mode`, `output.file`, `output.template` if those are defined in config-file. Sending empty string prevents defaults to be used as an cli arguments and config-file will be used.

Probably not a proper fix, but a workaround for https://github.com/terraform-docs/gh-actions/issues/84
<!-- Fixes # -->

I have:

- [x] Read and followed terraform-docs' [contribution process].

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/Jt3K5
