### PR TITLE
fix: replacing deprecated set-output to use env instead

### DIFF
--- a/src/docker-entrypoint.sh
+++ b/src/docker-entrypoint.sh
@@ -177,7 +177,7 @@ fi
 set +e
 num_changed=$(git_status)
 set -e
-echo "::set-output name=num_changed::${num_changed}"
+echo "num_changed=${num_changed}" >> $GITHUB_OUTPUT
 
 if [ "${INPUT_GIT_PUSH}" = "true" ]; then
     git_commit


### PR DESCRIPTION
### Description of your changes

Replacing deprecated `set-output` to use env `$GITHUB_OUTPUT` instead.

Blogg post about deprecation:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

I have:

- [X] Read and followed terraform-docs' [contribution process].
