### PR TITLE
Support documentation files outside of `working-dir` path

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ jobs:
 | indention | Indention level of Markdown sections [1, 2, 3, 4, 5] | `2` | false |
 | output-file | File in module directory where the docs should be placed | `README.md` | false |
 | output-format | terraform-docs format to generate content (see [all formats](https://github.com/terraform-docs/terraform-docs/blob/master/docs/FORMATS\_GUIDE.md)) (ignored if `config-file` is set) | `markdown table` | false |
-| output-method | Method should be one of `replace`, `inject`, or `print` | `inject` | false |
+| output-method | Method should be one of `replace`, `inject`, or `print`. Set as an empty string if `output.mode` and `output.file` are defined in config-file | `inject` | false |
 | recursive | If true it will update submodules recursively | `false` | false |
 | recursive-path | Submodules path to recursively update | `modules` | false |
-| template | When provided will be used as the template if/when the `output-file` does not exist | `<!-- BEGIN_TF_DOCS -->\n{{ .Content }}\n<!-- END_TF_DOCS -->` | false |
+| template | When provided will be used as the template if/when the `output-file` does not exist. Set as an empty string if `output.template` is defined in config-file | `<!-- BEGIN_TF_DOCS -->\n{{ .Content }}\n<!-- END_TF_DOCS -->` | false |
 | working-dir | Comma separated list of directories to generate docs for (ignored if `atlantis-file` or `find-dir` is set) | `.` | false |
 
 #### Output Method (output-method)

--- a/src/docker-entrypoint.sh
+++ b/src/docker-entrypoint.sh
@@ -147,7 +147,7 @@ update_doc() {
     fi
 
     if [ "${INPUT_OUTPUT_METHOD}" == "inject" ] || [ "${INPUT_OUTPUT_METHOD}" == "replace" ]; then
-        for modified_files in $(git ls-files -m | grep -i $(echo ${INPUT_OUTPUT_FILE} | cut -d'/' -f2- )); do
+        for modified_files in $(git ls-files -m | grep -i "$(echo "${INPUT_OUTPUT_FILE}" | cut -d'/' -f2- )"); do
             git_add "${modified_files}"
         done
     fi
@@ -179,7 +179,7 @@ fi
 set +e
 num_changed=$(git_status)
 set -e
-echo "num_changed=${num_changed}" >> $GITHUB_OUTPUT
+echo "num_changed=${num_changed}" >> "$GITHUB_OUTPUT"
 
 if [ "${INPUT_GIT_PUSH}" = "true" ]; then
     git_commit


### PR DESCRIPTION
<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/Jt3K5 if this is your first time opening a
terraform-docs pull request. Find us in https://slack.terraform-docs.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open terraform-docs issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

This PR includes changes to logic of staging files using `git add`. Currently logic does not support adding files changes if those files are outside of `working-dir`. Logic behind is changed to list all files that have been modified and then stage only files that are defied within `output-file` parameter of this GitHub action.

It also includes update to `README.md` and fixes to `docker-entrypoint.sh` script to pass Shellcheck scans.

<!-- Fixes # -->
https://github.com/terraform-docs/gh-actions/issues/93

I have:

- [x] Read and followed terraform-docs' [contribution process].

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Tests have been performed locally to make sure all strings are parsed correctly. Also all GitHub Actions workflows are passing.

[contribution process]: https://git.io/Jt3K5
