### PR TITLE
Adding git-sub-dir 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ first to see if there's already an issue relating to the thing you'd like to
 contribute. If there isn't, please raise a new one! Let us know what you'd like
 to work on, and why.
 
-Be sure to practice [good git commit hygiene] as you make your changes. All but
+Be sure to practice good git commit hygiene as you make your changes. All but
 the smallest changes should be broken up into a few commits that tell a story.
 Use your git commits to provide context for the folks who will review PR, and
 the folks who will be spelunking the codebase in the months and years to come.
@@ -57,6 +57,17 @@ Thank you for reading through our contributing guide! We appreciate you taking
 the time to ensure your contributions are high quality and easy for our community
 to review and accept.
 
+## Testing Code
+The [test workflow] uses [shellcheck] then [gomplate] to run [scripts/update-readme.sh].
+Run [shellcheck] against any shell files eg `shellcheck src/docker-entrypoint.sh`
+[scripts/update-readme.sh] can be run as is eg `./scripts/update-readme.sh`
+ note the default output is `README.md updated.` so you will need to use git diff or
+ similar to check for changes
+
+
 [Slack]: https://slack.terraform-docs.io/
-[good git commit hygiene]: https://www.futurelearn.com/info/blog/telling-stories-with-your-git-history
 [Developer Certificate of Origin]: https://github.com/apps/dco
+[test workflow]: https://github.com/terraform-docs/gh-actions/blob/main/.github/workflows/test.yml
+[shellcheck]: https://github.com/koalaman/shellcheck
+[gomplate]: https://github.com/hairyhenderson/gomplate/
+[scripts/update-readme.sh]: https://github.com/terraform-docs/gh-actions/blob/main/scripts/update-readme.sh

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ branch.
 
 ## Version
 
-`v1.2.0` (uses [terraform-docs] v0.18.0, which is supported and tested on Terraform
+`v1.2.1` (uses [terraform-docs] v0.18.0, which is supported and tested on Terraform
 version 0.11+ and 0.12+ but may work for others.)
 
 ### Upgrade v0 to v1
@@ -42,7 +42,7 @@ jobs:
         ref: ${{ github.event.pull_request.head.ref }}
 
     - name: Render terraform docs inside the README.md and push changes back to PR branch
-      uses: terraform-docs/gh-actions@v1.2.0
+      uses: terraform-docs/gh-actions@v1.2.1
       with:
         working-dir: .
         output-file: README.md
@@ -72,6 +72,7 @@ jobs:
 | git-push-sign-off | If true it will sign-off commit | `false` | false |
 | git-push-user-email | If empty the no-reply email of the GitHub Actions bot will be used (i.e. `github-actions[bot]@users.noreply.github.com`) | `""` | false |
 | git-push-user-name | If empty the name of the GitHub Actions bot will be used (i.e. `github-actions[bot]`) | `""` | false |
+| git-sub-dir | Subdirectory that terraform code is checked out into | `""` | false |
 | indention | Indention level of Markdown sections [1, 2, 3, 4, 5] | `2` | false |
 | output-file | File in module directory where the docs should be placed | `README.md` | false |
 | output-format | terraform-docs format to generate content (see [all formats](https://github.com/terraform-docs/terraform-docs/blob/master/docs/FORMATS\_GUIDE.md)) (ignored if `config-file` is set) | `markdown table` | false |
@@ -147,7 +148,7 @@ To enable you need to ensure a few things first:
 
 ```yaml
 - name: Generate TF Docs
-  uses: terraform-docs/gh-actions@v1.2.0
+  uses: terraform-docs/gh-actions@v1.2.1
   with:
     working-dir: .
 ```
@@ -156,7 +157,7 @@ To enable you need to ensure a few things first:
 
 ```yaml
 - name: Generate TF Docs
-  uses: terraform-docs/gh-actions@v1.2.0
+  uses: terraform-docs/gh-actions@v1.2.1
   with:
     working-dir: .,example1,example3/modules/test
 ```
@@ -165,7 +166,7 @@ To enable you need to ensure a few things first:
 
 ```yaml
 - name: Generate TF docs
-  uses: terraform-docs/gh-actions@v1.2.0
+  uses: terraform-docs/gh-actions@v1.2.1
   with:
     atlantis-file: atlantis.yaml
 ```
@@ -174,7 +175,7 @@ To enable you need to ensure a few things first:
 
 ```yaml
 - name: Generate TF docs
-  uses: terraform-docs/gh-actions@v1.2.0
+  uses: terraform-docs/gh-actions@v1.2.1
   with:
     find-dir: examples/
 ```
@@ -183,13 +184,13 @@ To enable you need to ensure a few things first:
 
 ```yaml
 - name: Generate TF docs
-  uses: terraform-docs/gh-actions@v1.2.0
+  uses: terraform-docs/gh-actions@v1.2.1
   with:
     working-dir: examples/
     recursive: true
     recursive-path: modules
 ```
 
-Complete examples can be found [here](https://github.com/terraform-docs/gh-actions/tree/v1.2.0/examples).
+Complete examples can be found [here](https://github.com/terraform-docs/gh-actions/tree/v1.2.1/examples).
 
 [terraform-docs]: https://github.com/terraform-docs/terraform-docs

--- a/action.yml
+++ b/action.yml
@@ -74,6 +74,10 @@ inputs:
     description: If true it will sign-off commit
     required: false
     default: "false"
+  git-sub-dir:
+    description: Subdirectory that terraform code is checked out into
+    required: false
+    default: ""
   fail-on-diff:
     description: Fail the job if there is any diff found between the generated output and existing file (ignored if `git-push` is set)
     required: false
@@ -85,7 +89,7 @@ outputs:
 
 runs:
   using: docker
-  image: "docker://quay.io/terraform-docs/gh-actions:1.2.0"
+  image: "docker://quay.io/terraform-docs/gh-actions:1.2.1"
   env:
     INPUT_WORKING_DIR: ${{ inputs.working-dir }}
     INPUT_ATLANTIS_FILE: ${{ inputs.atlantis-file }}
@@ -105,6 +109,7 @@ runs:
     INPUT_GIT_PUSH_SIGN_OFF: ${{ inputs.git-push-sign-off }}
     INPUT_GIT_PUSH_USER_NAME: ${{ inputs.git-push-user-name }}
     INPUT_GIT_PUSH_USER_EMAIL: ${{ inputs.git-push-user-email }}
+    INPUT_GIT_SUB_DIR: ${{ inputs.git-sub-dir }}
 
 branding:
   icon: file-text

--- a/src/docker-entrypoint.sh
+++ b/src/docker-entrypoint.sh
@@ -48,11 +48,16 @@ if [ -z "${INPUT_GIT_PUSH_USER_EMAIL}" ]; then
     INPUT_GIT_PUSH_USER_EMAIL="github-actions[bot]@users.noreply.github.com"
 fi
 
+if [ -n "${INPUT_GIT_SUB_DIR}" ]; then
+    GITHUB_WORKSPACE="${GITHUB_WORKSPACE}/${INPUT_GIT_SUB_DIR}"
+    echo "Using non-standard GITHUB_WORKSPACE of ${GITHUB_WORKSPACE}"
+fi
+
 git_setup() {
     # When the runner maps the $GITHUB_WORKSPACE mount, it is owned by the runner
     # user while the created folders are owned by the container user, causing this
     # error. Issue description here: https://github.com/actions/checkout/issues/766
-    git config --global --add safe.directory /github/workspace
+    git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
     git config --global user.name "${INPUT_GIT_PUSH_USER_NAME}"
     git config --global user.email "${INPUT_GIT_PUSH_USER_EMAIL}"


### PR DESCRIPTION
### Description of your changes

Fixes #102 

This action does not currently support code checked out to a directory other than the default

The following checkout would not work without this PR. 
```
    - name: Checkout - Modules
      uses: actions/checkout@v4
      with:
        token: ${{ secrets.GITHUB_TOKEN }}
        ref: ${{ github.event.pull_request.head.ref }}
        fetch-depth: 0
        path: modules
```
The above would generate the following error
```
fatal: not a git repository (or any parent up to mount point /github)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
```
Additionally if other repo's are checked out as a subdirectory this will commit that repo as sub-module. While this PR does not directly address the sub-module issue it allows its avoidance by supporting a directory other than `/github/workspace`

By introducing the `git-sub-dir` arg and passing that arg to the container we can append the directory. Then everything works as normal


I have:

- [x] Read and followed terraform-docs' [contribution process].

### How has this code been tested

I tested this by using the action `timothyclarke/tf-docs-gh-actions@d014534410793a9188ee6b3f1d465505e403db01` https://github.com/terraform-docs/gh-actions/compare/main...timothyclarke:tf-docs-gh-actions:checkout-dir 

Note that branch is slightly different from this PR as I needed to build the docker container and then reference my docker container.

With the above checkout command and the the following action
```
      - name: Terraform Docs
        #uses: terraform-docs/gh-actions@v1.2.0
        uses: timothyclarke/tf-docs-gh-actions@d014534410793a9188ee6b3f1d465505e403db01
        with:
          output-file: README.md
          output-method: inject
          git-push: "true"
          git-sub-dir: modules
```
The test output was
```
Run timothyclarke/tf-docs-gh-actions@d014534410793a9188ee6b3f1d465505e403db01
  with:
    output-file: README.md
    output-method: inject
    git-push: true
    git-sub-dir: modules
    config-file: disabled
    working-dir: .
    atlantis-file: disabled
    find-dir: disabled
    recursive: false
    recursive-path: modules
    output-format: markdown table
    template: <!-- BEGIN_TF_DOCS -->
  {{ .Content }}
  <!-- END_TF_DOCS -->
    indention: 2
    git-commit-message: terraform-docs: automated action
    git-push-sign-off: false
    fail-on-diff: false
  env:
    pythonLocation: /home/runner/_work/_tool/Python/3.12.5/x64
    PKG_CONFIG_PATH: /home/runner/_work/_tool/Python/3.12.5/x64/lib/pkgconfig
    Python_ROOT_DIR: /home/runner/_work/_tool/Python/3.12.5/x64
    Python2_ROOT_DIR: /home/runner/_work/_tool/Python/3.12.5/x64
    Python3_ROOT_DIR: /home/runner/_work/_tool/Python/3.12.5/x64
    LD_LIBRARY_PATH: /home/runner/_work/_tool/Python/3.12.5/x64/lib
    TERRAFORM_CLI_PATH: /home/runner/_work/_temp/781f4ff4-5bf4-4547-9c99-2ffc986ec800
```
```
Using non-standard GITHUB_WORKSPACE of /github/workspace/modules
::debug working_dir=.
::debug output_mode=inject
::debug output_file=README.md
::debug terraform-docs markdown table --indent 2 --output-mode inject --output-file README.md --output-template <!-- BEGIN_TF_DOCS -->
{{ .Content }}
<!-- END_TF_DOCS --> .
README.md updated successfully
::debug No change in ./ detected
::debug No files changed, skipping commit
```


[contribution process]: https://git.io/Jt3K5
