### PR TITLE
chore: revert the action name back for now

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: terraform-docs
+name: terraform-docs-gh-actions
 author: terraform-docs Authors
 description: Generate Terraform module documentation in pull requests
 


### PR DESCRIPTION
<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/Jt3K5 if this is your first time opening a
terraform-docs pull request. Find us in https://slack.terraform-docs.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open terraform-docs issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Revert the name of action back to `terraform-docs-gh-actions` for now to prevent collision. We can move forward to new name again once https://github.com/Dirrk/terraform-docs/pull/31 is merged and released.

<!-- Fixes # -->

I have:

- [ ] Read and followed terraform-docs' [contribution process].

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/Jt3K5
