### PR TITLE
fix: only run git if push or fail are enabled

### DIFF
--- a/src/docker-entrypoint.sh
+++ b/src/docker-entrypoint.sh
@@ -151,7 +151,7 @@ update_doc() {
         exit $success
     fi
 
-    if [ "${INPUT_OUTPUT_METHOD}" == "inject" ] || [ "${INPUT_OUTPUT_METHOD}" == "replace" ]; then
+    if { [ "${INPUT_OUTPUT_METHOD}" = "inject" ] || [ "${INPUT_OUTPUT_METHOD}" = "replace" ]; } && [ "${INPUT_GIT_PUSH}" = "true" ]; then
         git_add "${working_dir}/${OUTPUT_FILE}"
     fi
 }
@@ -159,7 +159,9 @@ update_doc() {
 # go to github repo
 cd "${GITHUB_WORKSPACE}"
 
-git_setup
+if [ "${INPUT_GIT_PUSH}" = "true" ] || [ "${INPUT_FAIL_ON_DIFF}" = "true" ]; then
+    git_setup
+fi
 
 if [ -f "${GITHUB_WORKSPACE}/${INPUT_ATLANTIS_FILE}" ]; then
     # Parse an atlantis yaml file
@@ -178,11 +180,13 @@ else
     done
 fi
 
-# always set num_changed output
-set +e
-num_changed=$(git_status)
-set -e
-echo "num_changed=${num_changed}" >> "$GITHUB_OUTPUT"
+if [ "${INPUT_GIT_PUSH}" = "true" ] || [ "${INPUT_FAIL_ON_DIFF}" = "true" ]; then
+    # set num_changed output only if git is enabled
+    set +e
+    num_changed=$(git_status)
+    set -e
+    echo "num_changed=${num_changed}" >> "$GITHUB_OUTPUT"
+fi
 
 if [ "${INPUT_GIT_PUSH}" = "true" ]; then
     git_commit


### PR DESCRIPTION
<!--
Thank you for helping to improve terraform-docs!

Please read through https://git.io/Jt3K5 if this is your first time opening a
terraform-docs pull request. Find us in https://slack.terraform-docs.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open terraform-docs issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

We can run the git commands only if the corresponding git features are enabled when calling the action. The background about this pull request is in the issue [delegate git responsability to other github actions](https://github.com/terraform-docs/gh-actions/issues/151). 

<!-- Fixes # -->
Related to https://github.com/terraform-docs/gh-actions/issues/151

I have:

- [x] Read and followed terraform-docs' [contribution process].

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

I haven't tested this change. I thought about how to test if git was disabled, that no git command was run, but it would involve adding an output to the action only for the sake of testing. Please let me know if you have any suggestions on how to test this change.

[contribution process]: https://git.io/Jt3K5
