### PR TITLE
Update terraform-docs to v0.24.0

### DIFF
--- a/.github/scripts/prepare-release.sh
+++ b/.github/scripts/prepare-release.sh
@@ -32,7 +32,7 @@ if [ -z "${NEW_VERSION}" ]; then
 fi
 
 if [ -z "${TF_DOCS_VERSION}" ]; then
-    TF_DOCS_VERSION=$(grep "FROM quay.io/terraform-docs/terraform-docs" "${PWD}"/../../Dockerfile | tr -s ' ' | uniq | cut -d":" -f2)
+    TF_DOCS_VERSION=$(grep "FROM quay.io/terraform-docs/terraform-docs" "${PWD}"/../../Dockerfile | tr -s ' ' | uniq | cut -d":" -f2 | sed 's/-${TARGETARCH}//')
 fi
 if [ -z "${TF_DOCS_VERSION}" ]; then
     echo "Usage: pre-release.sh <NEW_VERSION> <TF_DOCS_VERSION>"
@@ -47,7 +47,7 @@ VERSION=v${NEW_VERSION//v/} TERRAFORM_DOCS_VERSION=v${TF_DOCS_VERSION//v/} \
     -o "${PWD}"/../../README.md
 
 # Update Dockerfile
-sed -i -E "s|FROM quay.io/terraform-docs/terraform-docs:(.*)|FROM quay.io/terraform-docs/terraform-docs:${TF_DOCS_VERSION//v/}|g" "${PWD}"/../../Dockerfile
+sed -i -E "s|FROM quay.io/terraform-docs/terraform-docs:(.*)|FROM quay.io/terraform-docs/terraform-docs:${TF_DOCS_VERSION//v/}-\${TARGETARCH}|g" "${PWD}"/../../Dockerfile
 
 # Update action.yml
 sed -i -E "s|docker://quay.io/terraform-docs/gh-actions:(.*)\"|docker://quay.io/terraform-docs/gh-actions:${NEW_VERSION//v/}\"|g" "${PWD}"/../../action.yml

--- a/.github/scripts/prepare-release.sh
+++ b/.github/scripts/prepare-release.sh
@@ -32,7 +32,7 @@ if [ -z "${NEW_VERSION}" ]; then
 fi
 
 if [ -z "${TF_DOCS_VERSION}" ]; then
-    TF_DOCS_VERSION=$(grep "FROM quay.io/terraform-docs/terraform-docs" "${PWD}"/../../Dockerfile | tr -s ' ' | uniq | cut -d":" -f2 | sed 's/-${TARGETARCH}//')
+    TF_DOCS_VERSION=$(grep "FROM quay.io/terraform-docs/terraform-docs" "${PWD}/../Dockerfile" | sed -E 's/.*:([0-9.]+)-.*/\1/')
 fi
 if [ -z "${TF_DOCS_VERSION}" ]; then
     echo "Usage: pre-release.sh <NEW_VERSION> <TF_DOCS_VERSION>"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
             Should use the template defined instead of the default
             Should inject the table under usage
 
-            # Usage
+            ## Usage
 
             {{ .Content }}
             <!-- END_TF_DOCS -->
@@ -64,7 +64,7 @@ jobs:
           args: --sensitive=false --hide requirements --required=false
           indention: 3
 
-      - name: Should generate README.md for tf12_bsic
+      - name: Should generate README.md for tf12_basic
         uses: ./
         with:
           working-dir: examples/tf12_basic

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/terraform-docs/terraform-docs:0.20.0
+ARG TARGETARCH=amd64
+FROM quay.io/terraform-docs/terraform-docs:0.24.0-${TARGETARCH}
 
 RUN set -x \
     && apk update \

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ branch.
 
 ## Version
 
-`v1.4.1` (uses [terraform-docs] v0.20.0, which is supported and tested on Terraform
+`v1.4.1` (uses [terraform-docs] v0.24.0, which is supported and tested on Terraform
 version 0.11+ and 0.12+ but may work for others.)
 
 ### Upgrade v0 to v1

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,4 +2,4 @@
 
 These examples are committed with the documentation rendered just like a normal
 repo would.  They are generated using this github action on each build of the code.
-Which you can find [here](https://github.com/terraform-docs/gh-actions/tree/main/.github/workflows/build.yml).
+Which you can find [here](https://github.com/terraform-docs/gh-actions/tree/main/.github/workflows/ci.yml).

--- a/examples/tf11_basic/README.md
+++ b/examples/tf11_basic/README.md
@@ -17,7 +17,7 @@
       Should use the template defined instead of the default
       Should inject the table under usage
 
-      # Usage
+      ## Usage
 
       {{ .Content }}
       <!-- END_TF_DOCS -->

--- a/examples/tf11_basic/USAGE.md
+++ b/examples/tf11_basic/USAGE.md
@@ -11,14 +11,14 @@ Should inject the table under usage
 ### Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 2.2.0 |
 | <a name="requirement_consul"></a> [consul](#requirement\_consul) | >= 1.0.0 |
 
 ### Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | < 2.2.0 |
 | <a name="provider_consul"></a> [consul](#provider\_consul) | >= 1.0.0 |
 
@@ -29,14 +29,14 @@ No modules.
 ### Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_acm_certificate.test-cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/acm_certificate) | data source |
 | [consul_key.test](https://registry.terraform.io/providers/hashicorp/consul/latest/docs/data-sources/key) | data source |
 
 ### Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_extra_environment"></a> [extra\_environment](#input\_extra\_environment) | List of additional environment variables | `list` | `[]` | no |
 | <a name="input_extra_tags"></a> [extra\_tags](#input\_extra\_tags) | Additional tags | `map` | `{}` | no |
 | <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | Number of instances to create | `string` | `"1"` | no |
@@ -47,6 +47,6 @@ No modules.
 ### Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | The Id of the VPC |
 <!-- END_TF_DOCS -->

--- a/examples/tf11_extra_args/README.md
+++ b/examples/tf11_extra_args/README.md
@@ -7,7 +7,7 @@
   uses: ./
   with:
     working-dir: examples/tf11_extra_args
-    output-format: markdown document
+    output-format: markdown table
     output-file: USAGE.md
     output-method: replace
     args: --sensitive=false --hide requirements --required=false

--- a/examples/tf12_atlantis/README.md
+++ b/examples/tf12_atlantis/README.md
@@ -22,7 +22,7 @@
 ### Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 2.20.0 |
 | <a name="requirement_consul"></a> [consul](#requirement\_consul) | >= 2.4.0 |
 
@@ -33,14 +33,14 @@ No modules.
 ### Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_acm_certificate.test-cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/acm_certificate) | data source |
 | [consul_key.test](https://registry.terraform.io/providers/hashicorp/consul/latest/docs/data-sources/key) | data source |
 
 ### Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_extra_environment"></a> [extra\_environment](#input\_extra\_environment) | List of additional environment variables | <pre>list(object({<br/>    name  = string<br/>    value = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_extra_tags"></a> [extra\_tags](#input\_extra\_tags) | Additional tags | `map(string)` | `{}` | no |
 | <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | Number of instances to create | `number` | `1` | no |
@@ -51,6 +51,6 @@ No modules.
 ### Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | The Id of the VPC |
 <!-- END_TF_DOCS -->

--- a/examples/tf12_basic/README.md
+++ b/examples/tf12_basic/README.md
@@ -20,14 +20,14 @@
 ### Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 2.20.0 |
 | <a name="requirement_consul"></a> [consul](#requirement\_consul) | >= 2.4.0 |
 
 ### Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 2.20.0 |
 | <a name="provider_consul"></a> [consul](#provider\_consul) | >= 2.4.0 |
 
@@ -38,14 +38,14 @@ No modules.
 ### Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_acm_certificate.test-cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/acm_certificate) | data source |
 | [consul_key.test](https://registry.terraform.io/providers/hashicorp/consul/latest/docs/data-sources/key) | data source |
 
 ### Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_extra_environment"></a> [extra\_environment](#input\_extra\_environment) | List of additional environment variables | <pre>list(object({<br/>    name  = string<br/>    value = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_extra_tags"></a> [extra\_tags](#input\_extra\_tags) | Additional tags | `map(string)` | `{}` | no |
 | <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | Number of instances to create | `number` | `1` | no |
@@ -56,6 +56,6 @@ No modules.
 ### Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | The Id of the VPC |
 <!-- END_TF_DOCS -->

--- a/examples/tf12_config/README.md
+++ b/examples/tf12_config/README.md
@@ -21,7 +21,7 @@
 ### Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | A list of subnet ids to use | `list(string)` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The id of the vpc | `string` | n/a | yes |
 | <a name="input_extra_environment"></a> [extra\_environment](#input\_extra\_environment) | List of additional environment variables | <pre>list(object({<br/>    name  = string<br/>    value = string<br/>  }))</pre> | `[]` | no |

--- a/examples/tf12_fail_diff/README.md
+++ b/examples/tf12_fail_diff/README.md
@@ -21,14 +21,14 @@
 ### Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 2.20.0 |
 | <a name="requirement_consul"></a> [consul](#requirement\_consul) | >= 2.4.0 |
 
 ### Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 2.20.0 |
 | <a name="provider_consul"></a> [consul](#provider\_consul) | >= 2.4.0 |
 
@@ -39,14 +39,14 @@ No modules.
 ### Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_acm_certificate.test-cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/acm_certificate) | data source |
 | [consul_key.test](https://registry.terraform.io/providers/hashicorp/consul/latest/docs/data-sources/key) | data source |
 
 ### Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_extra_environment"></a> [extra\_environment](#input\_extra\_environment) | List of additional environment variables | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | `[]` | no |
 | <a name="input_extra_tags"></a> [extra\_tags](#input\_extra\_tags) | Additional tags | `map(string)` | `{}` | no |
 | <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | Number of instances to create | `number` | `1` | no |
@@ -57,6 +57,6 @@ No modules.
 ### Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | The Id of the VPC |
 <!-- END_TF_DOCS -->

--- a/examples/tf12_find/USAGE.md
+++ b/examples/tf12_find/USAGE.md
@@ -2,14 +2,14 @@
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 2.20.0 |
 | <a name="requirement_consul"></a> [consul](#requirement\_consul) | >= 2.4.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 2.20.0 |
 | <a name="provider_consul"></a> [consul](#provider\_consul) | >= 2.4.0 |
 
@@ -20,14 +20,14 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_acm_certificate.test-cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/acm_certificate) | data source |
 | [consul_key.test](https://registry.terraform.io/providers/hashicorp/consul/latest/docs/data-sources/key) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_extra_environment"></a> [extra\_environment](#input\_extra\_environment) | List of additional environment variables | <pre>list(object({<br/>    name  = string<br/>    value = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_extra_tags"></a> [extra\_tags](#input\_extra\_tags) | Additional tags | `map(string)` | `{}` | no |
 | <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | Number of instances to create | `number` | `1` | no |
@@ -38,6 +38,6 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | The Id of the VPC |
 <!-- END_TF_DOCS -->

--- a/examples/tf12_find/modules/tf12_find_submodules/USAGE.md
+++ b/examples/tf12_find/modules/tf12_find_submodules/USAGE.md
@@ -18,7 +18,7 @@ No resources.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_extra_environment"></a> [extra\_environment](#input\_extra\_environment) | List of additional environment variables | <pre>list(object({<br/>    name  = string<br/>    value = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_extra_tags"></a> [extra\_tags](#input\_extra\_tags) | Additional tags | `map(string)` | `{}` | no |
 | <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | Number of instances to create | `number` | `1` | no |
@@ -29,6 +29,6 @@ No resources.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | The Id of the VPC |
 <!-- END_TF_DOCS -->

--- a/examples/tf12_inject/README.md
+++ b/examples/tf12_inject/README.md
@@ -24,14 +24,14 @@
 ### Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 2.20.0 |
 | <a name="requirement_consul"></a> [consul](#requirement\_consul) | >= 2.4.0 |
 
 ### Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 2.20.0 |
 | <a name="provider_consul"></a> [consul](#provider\_consul) | >= 2.4.0 |
 
@@ -42,14 +42,14 @@ No modules.
 ### Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_acm_certificate.test-cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/acm_certificate) | data source |
 | [consul_key.test](https://registry.terraform.io/providers/hashicorp/consul/latest/docs/data-sources/key) | data source |
 
 ### Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | A list of subnet ids to use | `list(string)` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The id of the vpc | `string` | n/a | yes |
 | <a name="input_extra_environment"></a> [extra\_environment](#input\_extra\_environment) | List of additional environment variables | <pre>list(object({<br/>    name  = string<br/>    value = string<br/>  }))</pre> | `[]` | no |
@@ -60,6 +60,6 @@ No modules.
 ### Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | The Id of the VPC |
 <!-- END_TF_DOCS -->

--- a/scripts/update-readme.sh
+++ b/scripts/update-readme.sh
@@ -32,7 +32,7 @@ if [ -z "${NEW_VERSION}" ]; then
 fi
 
 if [ -z "${TF_DOCS_VERSION}" ]; then
-    TF_DOCS_VERSION=$(grep "FROM quay.io/terraform-docs/terraform-docs" "${PWD}"/../Dockerfile | tr -s ' ' | uniq | cut -d":" -f2)
+    TF_DOCS_VERSION=$(grep "FROM quay.io/terraform-docs/terraform-docs" "${PWD}"/../Dockerfile | tr -s ' ' | uniq | cut -d":" -f2 | sed 's/-${TARGETARCH}//')
 fi
 if [ -z "${TF_DOCS_VERSION}" ]; then
     echo "Usage: update-readme.sh <NEW_VERSION> <TF_DOCS_VERSION>"

--- a/scripts/update-readme.sh
+++ b/scripts/update-readme.sh
@@ -32,7 +32,7 @@ if [ -z "${NEW_VERSION}" ]; then
 fi
 
 if [ -z "${TF_DOCS_VERSION}" ]; then
-    TF_DOCS_VERSION=$(grep "FROM quay.io/terraform-docs/terraform-docs" "${PWD}"/../Dockerfile | tr -s ' ' | uniq | cut -d":" -f2 | sed 's/-${TARGETARCH}//')
+    TF_DOCS_VERSION=$(grep "FROM quay.io/terraform-docs/terraform-docs" "${PWD}/../Dockerfile" | sed -E 's/.*:([0-9.]+)-.*/\1/')
 fi
 if [ -z "${TF_DOCS_VERSION}" ]; then
     echo "Usage: update-readme.sh <NEW_VERSION> <TF_DOCS_VERSION>"


### PR DESCRIPTION
### Description of your changes

Upgrades the underlying version of `terraform-docs` to v0.24.0.

Deals with changes to Docker image labels to add architecture in repository <https://quay.io/terraform-docs/terraform-docs> introduced in v0.21.0.

Updates examples to use spaces in the delimiter row for Markdown tables https://github.com/terraform-docs/terraform-docs/pull/901

Fixes #160, #164

I have:

- [x] Read and followed terraform-docs' [contribution process].

### How has this code been tested

Testing to be performed by CI.